### PR TITLE
Export datetime in better parseable format (i.e. full years etc.)

### DIFF
--- a/lib/mdb/database.rb
+++ b/lib/mdb/database.rb
@@ -35,7 +35,7 @@ module Mdb
     
     
     def read_csv(table)
-      csv = execute "mdb-export -d \\| #{file_name} #{table}"
+      csv = execute "mdb-export -D '%F %T' -d \\| #{file_name} #{table}"
       empty_table!(table) if csv.empty?
       csv
     end
@@ -104,7 +104,7 @@ module Mdb
     
     
     def open_csv(table)
-      command = "mdb-export -d #{Shellwords.escape(delimiter)} #{file_name} #{table}"
+      command = "mdb-export -D '%F %T' -d #{Shellwords.escape(delimiter)} #{file_name} #{table}"
       Open3.popen3(command) do |stdin, stdout, stderr|
         yield CSV.new(stdout, col_sep: delimiter)
       end


### PR DESCRIPTION
By default mdb-export will export dates in a format like: "08/31/04 23:59:00". This is very unpractical, because we don't know whether the year should be 2004 or 1904. This modification exports the date in a format such as: '31-08-1904 23:59:00', which is directly parseable using DateTime.parse and includes the century correctly.
