### PR TITLE
fix for parsing tables

### DIFF
--- a/lib/mdb/database.rb
+++ b/lib/mdb/database.rb
@@ -24,7 +24,7 @@ module Mdb
     
     
     def tables
-      @tables ||= execute("mdb-tables -1 #{file_name}").scan(/^\w+$/)
+      @tables ||= execute("mdb-tables -1 #{file_name}").scan(/[^\n]+/)
     end
     
     


### PR DESCRIPTION
I was using mdb tables with names that are more than one word, so the regex needed updating.
